### PR TITLE
TC-165: Corrects the SciReg-SciAuthZ permissions check with correct j…

### DIFF
--- a/app/SciReg/sciauthz_services.py
+++ b/app/SciReg/sciauthz_services.py
@@ -67,7 +67,7 @@ def user_has_single_profile_view_permission(jwt_headers, project, email):
         user_permissions = {"count":0}
 
     if user_permissions["count"] > 0:
-        return user_permissions["results"][0]["permissions"] == "VIEW"
+        return user_permissions["results"][0]["permission"] == "VIEW"
     else:
         return False
 


### PR DESCRIPTION
…son element

Element coming from SciAuthZ is permission not permissions. This bug prevented SciReg from correctly intrepreting permissions for specific items i.e. SciReg.n2c2-t1.profile.natebessa+e2@gmail.com